### PR TITLE
texture2D is deprecated

### DIFF
--- a/shaders/post.frag
+++ b/shaders/post.frag
@@ -9,5 +9,5 @@ uniform sampler2D u_texture;
 
 void main()
 {
-	frag_color = texture2D(u_texture, v_texcoord);
+	frag_color = texture(u_texture, v_texcoord);
 }


### PR DESCRIPTION
texture2d is being replaced by texture. This cause several issues in many of @angeluriot 's repo.
Some sources are given in [this thread](https://stackoverflow.com/questions/12307278/texture-vs-texture2d-in-glsl)